### PR TITLE
Tiny bugfix

### DIFF
--- a/Validator.js
+++ b/Validator.js
@@ -38,7 +38,7 @@ sap.ui.define([
 	 * @return {boolean} whether the oControl is valid or not.
      */
     Validator.prototype.validate = function(oControl) {
-		this._isValid = false;
+        this._isValid = true;
         sap.ui.getCore().getMessageManager().removeAllMessages();
         this._validate(oControl);
         return this.isValid();

--- a/Validator.js
+++ b/Validator.js
@@ -38,6 +38,7 @@ sap.ui.define([
 	 * @return {boolean} whether the oControl is valid or not.
      */
     Validator.prototype.validate = function(oControl) {
+		this._isValid = false;
         sap.ui.getCore().getMessageManager().removeAllMessages();
         this._validate(oControl);
         return this.isValid();


### PR DESCRIPTION
Need to set the validation result to true when the validator is started. This prevents it from returning an erroneous false on second run.