### PR TITLE
Validating [ required controls, having no type | pickers ]; Setting ValueState.Error in case of invalidity

### DIFF
--- a/Validator.js
+++ b/Validator.js
@@ -1,9 +1,10 @@
 /*global sap */
 
 sap.ui.define([
-    'sap/ui/core/message/Message',
-    'sap/ui/core/MessageType'
-], function (Message, MessageType) {
+    "sap/ui/core/message/Message",
+    "sap/ui/core/MessageType",
+    "sap/ui/core/ValueState"
+], function (Message, MessageType, ValueState) {
     "use strict";
 
     /**
@@ -60,74 +61,104 @@ sap.ui.define([
             i, j, editable;
 
         // only validate controls and elements which have a 'visible' property
-        if (oControl instanceof sap.ui.core.Control ||
-            oControl instanceof sap.ui.layout.form.FormContainer ||
-            oControl instanceof sap.ui.layout.form.FormElement) {
-
-            // only check visible controls (invisible controls make no sense checking)
-            if (oControl.getVisible()) {
-
-                // check control for any properties worth validating 
-                for (i = 0; i < aValidateProperties.length; i += 1) {
-                    if (oControl.getBinding(aValidateProperties[i])) {
-                        // check if a data type exists (which may have validation constraints)
-                        if (oControl.getBinding(aValidateProperties[i]).getType()) {
-                        	try {
-								editable = oControl.getProperty("editable");
-                        	}
-                        	catch (ex) {
-                        		editable = true;
-                        	}
-
-							if (editable) {
-								// try validating the bound value
-								try {
-									oControlBinding = oControl.getBinding(aValidateProperties[i]);
-									oExternalValue  = oControl.getProperty(aValidateProperties[i]);
-									oInternalValue  = oControlBinding.getType().parseValue(oExternalValue, oControlBinding.sInternalType);
-									oControlBinding.getType().validateValue(oInternalValue);
-								}
-								// catch any validation errors
-								catch (ex) {
-									this._isValid = false;
-									oControlBinding = oControl.getBinding(aValidateProperties[i]);
-									sap.ui.getCore().getMessageManager().addMessages(
-										new Message({
-											message  : ex.message,
-											type     : MessageType.Error,
-											target   : ( oControlBinding.getContext() ? oControlBinding.getContext().getPath() + "/" : "") +
-													oControlBinding.getPath(),
-											processor: oControl.getBinding(aValidateProperties[i]).getModel()
-										})
-									);
-								}
-
-								isValidatedControl = true;
-							}
-                        }
+        // and are visible controls (invisible controls make no sense checking)
+        if (( oControl instanceof sap.ui.core.Control 
+	          || oControl instanceof sap.ui.layout.form.FormContainer
+	          || oControl instanceof sap.ui.layout.form.FormElement
+            ) && oControl.getVisible() ) {
+           
+            // check control for any properties worth validating 
+            for (i = 0; i < aValidateProperties.length; i += 1) {
+                if (oControl.getBinding(aValidateProperties[i]) 
+                    	// check if a data type exists (which may have validation constraints)
+                        && oControl.getBinding(aValidateProperties[i]).getType() 
+                        ) {
+                	try { oControl.getProperty("editable"); }
+                	catch (ex) { editable = true; }
+                    
+                    if(editable) {
+	                    try { // try validating the bound value
+	                        oControlBinding = oControl.getBinding(aValidateProperties[i]);
+	                        oExternalValue  = oControl.getProperty(aValidateProperties[i]);
+	                        oInternalValue  = oControlBinding.getType().parseValue(oExternalValue, oControlBinding.sInternalType);
+	                        oControlBinding.getType().validateValue(oInternalValue);
+	                    }
+	                    
+	                    catch (ex) { // catch any validation errors
+	                        this._isValid = false;
+	                        oControl.setValueState(ValueState.Error);
+	
+	                        oControlBinding = oControl.getBinding(aValidateProperties[i]);
+	                        sap.ui.getCore().getMessageManager().addMessages(
+	                            new Message({
+	                                message  : ex.message,
+	                                type     : MessageType.Error,
+	                                target   : ( oControlBinding.getContext() ? oControlBinding.getContext().getPath() + "/" : "") +
+	                                        oControlBinding.getPath(),
+	                                processor: oControl.getBinding(aValidateProperties[i]).getModel()
+	                            })
+	                        );
+	                    }
+	
+	                    isValidatedControl = true;
                     }
+
+                } else if (oControl.getRequired 
+                        && oControl.getRequired() === true ) {
+                    try {
+                        oControlBinding = oControl.getBinding(aValidateProperties[i]);
+                        oExternalValue = oControl.getProperty(aValidateProperties[i]);
+                        
+                        if (!oExternalValue || oExternalValue==="") {
+                            this._isValid = false;
+                            var oMessage = "Please fill this mandatory field!";
+                            oControl.setValueState(ValueState.Error, oMessage);
+                            
+                            sap.ui.getCore().getMessageManager().addMessages(
+                                new Message({
+                                    message: oMessage,
+                                    type: MessageType.Error,
+                                    target : ( oControlBinding.getContext() ? oControlBinding.getContext().getPath() + "/" : "") +
+                                    oControlBinding.getPath(),
+                                    processor: oControl.getBinding(aValidateProperties[i]).getModel()
+                                })
+                            );
+                        } else if (oControl.getAggregation("picker") 
+                                && oControl.getProperty("selectedKey").length === 0 ) { // might be a select 
+                            this._isValid = false;
+                            //TODO: i18n this
+                            oControl.setValueState(ValueState.Error, "Please choose an entry!");
+                        } else {
+                            oControl.setValueState(ValueState.None);
+                        }
+                    } catch (ex) {
+                        // Validation failed
+                    }
+                } else {
+                    //oControl.setValueState(ValueState.None);
                 }
+            }
 
-                // if the control could not be validated, it may have aggregations
-                if (!isValidatedControl) {
-                    for (i = 0; i < aPossibleAggregations.length; i += 1) {
-                        aControlAggregation = oControl.getAggregation(aPossibleAggregations[i]);
+            // if the control could not be validated, it may have aggregations
+            if (!isValidatedControl) {
+                for (i = 0; i < aPossibleAggregations.length; i += 1) {
+                    aControlAggregation = oControl.getAggregation(aPossibleAggregations[i]);
 
-                        if (aControlAggregation) {
-                            // generally, aggregations are of type Array
-                            if (aControlAggregation instanceof Array) {
-                                for (j = 0; j < aControlAggregation.length; j += 1) {
-                                    this._validate(aControlAggregation[j]);
-                                }
+                    if (aControlAggregation) {
+                        // generally, aggregations are of type Array
+                        if (aControlAggregation instanceof Array) {
+                            for (j = 0; j < aControlAggregation.length; j += 1) {
+                                this._validate(aControlAggregation[j]);
                             }
-                            // ...however, with sap.ui.layout.form.Form, it is a single object *sigh*
-                            else {
-                                this._validate(aControlAggregation);
-                            }
+                        }
+                        // ...however, with sap.ui.layout.form.Form, it is a single object *sigh*
+                        else {
+                            this._validate(aControlAggregation);
                         }
                     }
                 }
             }
+            
         }
         this._isValidationPerformed = true;
     };


### PR DESCRIPTION
- validation of inputs just bound via value="{Name}", having required = true
- validation of selects / pickers
- setting ValueState.Error if validation fails

Should still be drop-in compatible with the original Validator.
