### PR TITLE
Correction required fields

### DIFF
--- a/Validator.js
+++ b/Validator.js
@@ -130,6 +130,7 @@ sap.ui.define([
                             oControl.setValueState(ValueState.Error, "Please choose an entry!");
                         } else {
                             oControl.setValueState(ValueState.None);
+			    break;
                         }
                     } catch (ex) {
                         // Validation failed


### PR DESCRIPTION
Hello,

I corrected a bug for required values.
When the required input is filled, the first validation set the state to None, but if you validate a second time, the field's state gets set back to Error again.
The break allows to exit the "for loop" if there's a valid binding with an actual value.

I forked your plunker to reproduce the bug : http://plnkr.co/edit/2Wi9DVwJ80fsjznAyTUT?p=preview

Thank you so much for your work , by the way !

PS: Sorry for the duplicate issue #15 , I pushed other irrelevant commits.