### PR TITLE
Fix for cases when there is no label

### DIFF
--- a/Validator.js
+++ b/Validator.js
@@ -246,8 +246,10 @@ sap.ui.define(
         case "sap.m.Select":
           sLabel = oControl
             .getParent()
+            .getLabel ? oControl
+            .getParent()
             .getLabel()
-            .getText();
+            .getText() : "No Label Found";
           break;
       }
 


### PR DESCRIPTION
I added a check for labels instead of assuming that there will always be a label for Input fields, savings exceptions.